### PR TITLE
adding the docker compose binary file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for wordpress-docker
 system_user: ubuntu
 compose_project_dir: /home/{{ system_user }}/compose-wordpress
+compose_binary_dir: /usr/local/bin
 domain: foolcontrol.org
 stage: staging
 wp_version: 5.2.4

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,8 @@
     mode: 0644
 
 - name: Run docker-compose up
-  command: docker-compose -f docker-compose.yml up -d
+  command:
+    cmd: "{{ compose_binary_dir }}/docker-compose -f docker-compose.yml up -d"
   args:
     chdir: "{{ compose_project_dir }}"
 


### PR DESCRIPTION
I encountered issues while running the docker compose command. To fix this, I made changes to the defaults/main.yml file. I added the binary path for the docker compose file and included this path during the execution of docker compose.